### PR TITLE
Simplify app-icon-grid.svg markup

### DIFF
--- a/app-icon/app-icon-grid.svg
+++ b/app-icon/app-icon-grid.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
-  <g fill="none" stroke="#fff" stroke-width="0.8%" opacity="20%">
+<svg width="128" height="128" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" stroke="currentcolor" stroke-width="0.8%" opacity="20%">
     <circle cx="50%" cy="50%" r="46.875%" />
     <rect rx="6.25%" ry="6.25%" x="9.375%" y="9.375%" height="81.25%" width="81.25%" />
   </g>

--- a/app-icon/app-icon-grid.svg
+++ b/app-icon/app-icon-grid.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
-  <g fill="none" stroke="#fff" opacity="0.2">
-    <circle cx="64" cy="64" r="60" />
-    <rect rx="8" ry="8" x="12" y="12" height="104" width="104" />
+  <g fill="none" stroke="#fff" stroke-width="0.8%" opacity="20%">
+    <circle cx="50%" cy="50%" r="46.875%" />
+    <rect rx="6.25%" ry="6.25%" x="9.375%" y="9.375%" height="81.25%" width="81.25%" />
   </g>
 </svg>

--- a/app-icon/app-icon-grid.svg
+++ b/app-icon/app-icon-grid.svg
@@ -1,58 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   width="128.00002"
-   height="127.99999"
-   viewBox="0 0 33.866671 33.866665"
-   version="1.1"
-   id="svg1"
-   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
-   sodipodi:docname="grid1.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="px"
-     inkscape:zoom="1"
-     inkscape:cx="41.5"
-     inkscape:cy="68"
-     inkscape:window-width="1920"
-     inkscape:window-height="1011"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
-  <defs
-     id="defs1" />
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(-32.279167,-138.64166)">
-    <circle
-       cx="49.212509"
-       cy="155.575"
-       r="15.743801"
-       id="circle2892"
-       style="display:inline;opacity:0.2;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2619375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
-    <rect
-       ry="2.096508"
-       rx="2.096508"
-       y="141.94769"
-       x="35.585205"
-       height="27.254602"
-       width="27.254602"
-       id="rect2896"
-       style="display:inline;opacity:0.2;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2619375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" stroke="#fff" opacity="0.2">
+    <circle cx="64" cy="64" r="60" />
+    <rect rx="8" ry="8" x="12" y="12" height="104" width="104" />
   </g>
 </svg>

--- a/app-icon/app-icon-grid.svg
+++ b/app-icon/app-icon-grid.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="128" height="128" xmlns="http://www.w3.org/2000/svg">
   <g fill="none" stroke="currentcolor" stroke-width="0.8%" opacity="20%">
-    <circle cx="50%" cy="50%" r="46.875%" />
-    <rect rx="6.25%" ry="6.25%" x="9.375%" y="9.375%" height="81.25%" width="81.25%" />
+    <circle cx="50%" cy="50%" r="46.5%" />
+    <rect rx="6.25%" ry="6.25%" x="9.75%" y="9.75%" height="80.5%" width="80.5%" />
   </g>
 </svg>


### PR DESCRIPTION
SVG generated with Inkscape adds a ton of metadata and uses weird decimal numbers that increase the size of the markup and makes the result almost impossible to easily change without using Inkscape again.

Writing simple SVG will make it easier to use this pattern on top of existing SVG icons since it uses whole numbers that can be scaled to fit. As an example, just pasting the contents on another icon and changing the `stroke` to `red` will provide this very helpful preview:

![image](https://github.com/user-attachments/assets/62f41003-492f-4d1d-b5b8-f9cf0debcf90)

I opted to use percentages instead because they will scale to whatever the icon dimensions and viewbox size are. This will, of course, not work for non-square icons, but that's a requirement already.